### PR TITLE
Update/edge cases and fixes

### DIFF
--- a/taohash/core/storage/base_storage.py
+++ b/taohash/core/storage/base_storage.py
@@ -6,7 +6,6 @@ import bittensor
 
 
 class BaseStorage(ABC):
-
     @classmethod
     @abstractmethod
     def add_args(cls, parser: "ArgumentParser"):
@@ -33,3 +32,20 @@ class BaseStorage(ABC):
         parser = ArgumentParser()
         self.add_args(parser)
         return bittensor.config(parser)
+
+    def generate_user_id(self, config: "bittensor.config") -> str:
+        """
+        Generate a unique prefix for storage based on neuron's identity.
+
+        Args:
+            config: Bittensor config containing wallet and network info
+
+        Returns:
+            str: A unique prefix string for this neuron
+        """
+        network = getattr(config.subtensor, "network", "unknown")
+        wallet_name = getattr(config.wallet, "name", "unknown")
+        wallet_hotkey = getattr(config.wallet, "hotkey", "unknown")
+        netuid = getattr(config, "netuid", "unknown")
+
+        return f"{network}_{netuid}_{wallet_name}_{wallet_hotkey}"

--- a/taohash/core/storage/json_storage.py
+++ b/taohash/core/storage/json_storage.py
@@ -97,8 +97,6 @@ class BaseJsonStorage(BaseStorage):
             prefix = "schedule"
             save_data(current_block, data, prefix)
         """
-        # do cleanup check each time before saving new json data
-        self._cleanup()
 
         dynamic_files_path = _get_dynamic_files_path(self.path, prefix)
 

--- a/taohash/core/storage/json_storage.py
+++ b/taohash/core/storage/json_storage.py
@@ -35,11 +35,14 @@ def _get_dynamic_files_path(path: Path, prefix: str):
 
 
 class BaseJsonStorage(BaseStorage):
-
     def __init__(self, config=None):
         self.config = config or self.get_config()
 
-        self.path = Path(self.config.json_path).expanduser() if getattr(self.config, "json_path", None) else DEFAULT_PATH
+        self.path = (
+            Path(self.config.json_path).expanduser()
+            if getattr(self.config, "json_path", None)
+            else DEFAULT_PATH
+        )
         self.path.mkdir(parents=True, exist_ok=True)
         self.json_ttl = self.config.json_ttl or DEFAULT_JSON_TTL
 
@@ -76,7 +79,9 @@ class BaseJsonStorage(BaseStorage):
                     file.unlink()
                     logging.info(f"Deleted old file: {file.as_posix()}")
             except Exception as e:
-                logging.error(f"Error while trying to delete {file.as_posix()}: {str(e)}")
+                logging.error(
+                    f"Error while trying to delete {file.as_posix()}: {str(e)}"
+                )
 
     def save_data(self, key: Optional[Any], data: Any, prefix: str = "pools") -> None:
         """Save pool data for specific block.
@@ -97,6 +102,7 @@ class BaseJsonStorage(BaseStorage):
             prefix = "schedule"
             save_data(current_block, data, prefix)
         """
+        self._cleanup()
 
         dynamic_files_path = _get_dynamic_files_path(self.path, prefix)
 
@@ -172,5 +178,7 @@ class BaseJsonStorage(BaseStorage):
             latest_file = max(files, key=extract_block_number)
             return _read_json(latest_file)
         except (IndexError, ValueError):
-            logging.error(f"No [red]{prefix}[/red] files found in [blue]{dynamic_files_path.as_posix()}[/blue].")
+            logging.error(
+                f"No [red]{prefix}[/red] files found in [blue]{dynamic_files_path.as_posix()}[/blue]."
+            )
             return None

--- a/taohash/core/storage/redis_storage.py
+++ b/taohash/core/storage/redis_storage.py
@@ -29,7 +29,6 @@ class BaseRedisStorage(BaseStorage):
     def update_redis_client(self):
         """Update redis client configuration."""
         self.client.config_set(name="appendonly", value="yes")
-        self.client.config_rewrite()
 
     def check_health(self):
         """Check redis connection health."""

--- a/taohash/core/storage/utils.py
+++ b/taohash/core/storage/utils.py
@@ -19,17 +19,16 @@ def check_key(key):
 
 
 def dumps(obj) -> bytes:
-    """pickle + light zlib compression."""
-    # You can choose not to use zlib - will be easier to use data in other services
+    """pickle compression."""
     try:
         return pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
     except Exception as e:
-        raise Exception(f"Failed to pickle and compress object: {e}")
+        raise Exception(f"Failed to pickle object: {e}")
 
 
 def loads(blob: bytes):
-    """pickle + light zlib decompression."""
+    """pickle decompression."""
     try:
         return pickle.loads(blob)
     except Exception as e:
-        raise Exception(f"Failed to decompress and unpickle object: {e}")
+        raise Exception(f"Failed to unpickle object: {e}")

--- a/taohash/miner/__init__.py
+++ b/taohash/miner/__init__.py
@@ -16,7 +16,7 @@ class BaseMiner:
         self.config = self.get_config()
         self.setup_logging()
         self.setup_bittensor_objects()
-        self.storage = get_miner_storage(storage_type="json", config=self.config)
+        self.storage = get_miner_storage(storage_type=self.config.storage, config=self.config)
 
         self.worker_id = self.create_worker_id()
         self.tempo = self.subtensor.tempo(self.config.netuid)
@@ -62,6 +62,13 @@ class BaseMiner:
             if os.getenv("BLACKLIST")
             else [],
             help="List of validator hotkeys to exclude from mining",
+        )
+        parser.add_argument(
+            "--storage",
+            type=str,
+            choices=["json", "redis"],
+            default=os.getenv("STORAGE_TYPE", "json"),
+            help="Storage type to use (json or redis)",
         )
 
         # Add other base arguments

--- a/taohash/miner/braiins.py
+++ b/taohash/miner/braiins.py
@@ -130,7 +130,10 @@ class BraiinsMiner(BaseMiner):
                     f"Mining slot updated at block {self.current_block} from recovered schedule."
                 )
             else:
-                logging.info("No slot change detected - current slot is still valid.")
+                current_slot = self.mining_scheduler.current_schedule.current_slot
+                logging.info(
+                    f"No slot change detected - current slot is still valid: \n{current_slot}"
+                )
 
     def sync_and_refresh(self) -> None:
         """

--- a/taohash/miner/storage.py
+++ b/taohash/miner/storage.py
@@ -18,8 +18,6 @@ class JsonStorage(BaseJsonStorage):
     def save_pool_data(self, block_number: int, pool_mapping: dict) -> None:
         """Save pool data for specific block."""
         prefix = f"{self.miner_id}_pools"
-        # Do cleanup check each time before saving new json data
-        self._cleanup()
         self.save_data(key=block_number, data=pool_mapping, prefix=prefix)
 
     def get_pool_info(self, block_number: int) -> Optional[dict]:

--- a/taohash/miner/storage.py
+++ b/taohash/miner/storage.py
@@ -13,28 +13,36 @@ from taohash.core.storage.utils import dumps, loads
 class JsonStorage(BaseJsonStorage):
     def __init__(self, config: Optional["Config"] = None):
         super().__init__(config)
+        self.miner_id = self.generate_user_id(config)
 
     def save_pool_data(self, block_number: int, pool_mapping: dict) -> None:
         """Save pool data for specific block."""
-        self.save_data(key=block_number, data=pool_mapping)
+        prefix = f"{self.miner_id}_pools"
+        self.save_data(key=block_number, data=pool_mapping, prefix=prefix)
 
     def get_pool_info(self, block_number: int) -> Optional[dict]:
         """Get pool info for specific block."""
-        return self.load_data(key=block_number)
+        prefix = f"{self.miner_id}_pools"
+        return self.load_data(key=block_number, prefix=prefix)
 
     def get_latest_pool_info(self) -> Optional[dict]:
         """Get most recent pool info."""
-        return self.get_latest()
+        prefix = f"{self.miner_id}_pools"
+        return self.get_latest(prefix=prefix)
 
     def save_schedule(self, block_number: int, schedule_obj) -> None:
         readable_data = json.dumps(schedule_obj, default=lambda x: x.__dict__)
         dumped_data = dumps(schedule_obj)
         string_data = base64.b64encode(dumped_data).decode("utf-8")
         dict_data = {"data": readable_data, "data_encoded": string_data}
-        self.save_data(key=block_number, data=dict_data, prefix="schedule")
+        prefix = f"{self.miner_id}_schedule"
+        self.save_data(key=block_number, data=dict_data, prefix=prefix)
 
     def load_latest_schedule(self):
-        data = self.get_latest("schedule")
+        prefix = f"{self.miner_id}_schedule"
+        data = self.get_latest(prefix=prefix)
+        if data is None:
+            return None
         string_data = data.get("data_encoded")
         decoded_data = base64.b64decode(string_data.encode("utf-8"))
         return loads(decoded_data)
@@ -43,23 +51,29 @@ class JsonStorage(BaseJsonStorage):
 class RedisStorage(BaseRedisStorage):
     def __init__(self, config: Optional["Config"] = None):
         super().__init__(config)
+        self.miner_id = self.generate_user_id(config)
 
     # Pool data
     def save_pool_data(self, block_number: int, pool_mapping: dict) -> None:
-        self.save_data(key=block_number, data=pool_mapping)
+        prefix = f"{self.miner_id}_pools"
+        self.save_data(key=block_number, data=pool_mapping, prefix=prefix)
 
     def get_pool_info(self, block_number: int) -> Optional[dict]:
-        return self.load_data(key=block_number)
+        prefix = f"{self.miner_id}_pools"
+        return self.load_data(key=block_number, prefix=prefix)
 
     def get_latest_pool_info(self) -> Optional[dict]:
-        return self.get_latest()
+        prefix = f"{self.miner_id}_pools"
+        return self.get_latest(prefix=prefix)
 
     # Schedule data
     def save_schedule(self, block_number: int, schedule_obj) -> None:
-        self.save_data(key=block_number, data=schedule_obj, prefix="schedule")
+        prefix = f"{self.miner_id}_schedule"
+        self.save_data(key=block_number, data=schedule_obj, prefix=prefix)
 
     def load_latest_schedule(self):
-        return self.get_latest("schedule")
+        prefix = f"{self.miner_id}_schedule"
+        return self.get_latest(prefix=prefix)
 
 
 STORAGE_CLASSES = {"json": JsonStorage, "redis": RedisStorage}

--- a/taohash/miner/storage.py
+++ b/taohash/miner/storage.py
@@ -18,6 +18,8 @@ class JsonStorage(BaseJsonStorage):
     def save_pool_data(self, block_number: int, pool_mapping: dict) -> None:
         """Save pool data for specific block."""
         prefix = f"{self.miner_id}_pools"
+        # Do cleanup check each time before saving new json data
+        self._cleanup()
         self.save_data(key=block_number, data=pool_mapping, prefix=prefix)
 
     def get_pool_info(self, block_number: int) -> Optional[dict]:

--- a/taohash/validator/__init__.py
+++ b/taohash/validator/__init__.py
@@ -9,7 +9,11 @@ from tabulate import tabulate
 from taohash.core.constants import BLOCK_TIME
 from taohash.core.pool import Pool
 from taohash.core.pricing import CoinPriceAPI
-from taohash.validator.storage import JsonValidatorStorage, get_validator_storage
+from taohash.validator.storage import (
+    JsonValidatorStorage,
+    RedisValidatorStorage,
+    get_validator_storage,
+)
 
 TESTNET_NETUID = 332
 
@@ -20,7 +24,9 @@ class BaseValidator:
         self.config = self.get_config()
         self.setup_logging_path()
         self.setup_logging()
-        self.storage = get_validator_storage(storage_type=self.config.storage, config=self.config)
+        self.storage = get_validator_storage(
+            storage_type=self.config.storage, config=self.config
+        )
 
         self.subtensor = None
         self.wallet = None
@@ -84,6 +90,7 @@ class BaseValidator:
         Pool.add_args(parser)
         CoinPriceAPI.add_args(parser)
         JsonValidatorStorage.add_args(parser)
+        RedisValidatorStorage.add_args(parser)
 
     def setup_logging_path(self) -> None:
         """Set up logging directory."""
@@ -156,7 +163,7 @@ class BaseValidator:
             "hotkeys": self.hotkeys,
             "current_block": self.current_block,
         }
-        self.storage.save_state(self.current_block, state)
+        self.storage.save_state(state)
         logging.info(f"Saved validator state at block {self.current_block}")
 
     def resync_metagraph(self) -> None:

--- a/taohash/validator/__init__.py
+++ b/taohash/validator/__init__.py
@@ -20,7 +20,7 @@ class BaseValidator:
         self.config = self.get_config()
         self.setup_logging_path()
         self.setup_logging()
-        self.storage = get_validator_storage(storage_type="json", config=self.config)
+        self.storage = get_validator_storage(storage_type=self.config.storage, config=self.config)
 
         self.subtensor = None
         self.wallet = None
@@ -56,7 +56,6 @@ class BaseValidator:
             default=os.getenv("NETUID", TESTNET_NETUID),
             help="The chain subnet uid.",
         )
-
         parser.add_argument(
             "--eval_interval",
             type=int,
@@ -69,6 +68,13 @@ class BaseValidator:
             choices=["restore", "fresh"],
             default="restore",
             help="Whether to restore previous validator state ('restore') or start fresh ('fresh').",
+        )
+        parser.add_argument(
+            "--storage",
+            type=str,
+            choices=["json", "redis"],
+            default=os.getenv("STORAGE_TYPE", "json"),
+            help="Storage type to use (json or redis)",
         )
 
         # Other argument providers

--- a/taohash/validator/storage.py
+++ b/taohash/validator/storage.py
@@ -7,47 +7,56 @@ from taohash.core.storage import BaseJsonStorage, BaseRedisStorage
 
 
 class JsonValidatorStorage(BaseJsonStorage):
-
     def __init__(self, config: Optional["Config"] = None):
         super().__init__(config)
+        self.validator_id = self.generate_user_id(config)
 
     def save_state(self, block_number: int, state: dict) -> None:
         """Save validator state to a single JSON file."""
-        self.save_data(key=block_number, data=state, prefix="state")
+        prefix = f"{self.validator_id}_state"
+        self.save_data(key=block_number, data=state, prefix=prefix)
         logging.debug(f"Saved validator state at block {state['current_block']}")
 
     def get_state(self, block_number: int) -> dict:
         """Get validator state for specific block."""
-        return self.load_data(key=block_number, prefix="state")
+        prefix = f"{self.validator_id}_state"
+        return self.load_data(key=block_number, prefix=prefix)
 
     def load_latest_state(self) -> dict:
         """Load the latest saved validator state."""
-        return self.get_latest(prefix="state")
+        prefix = f"{self.validator_id}_state"
+        return self.get_latest(prefix=prefix)
 
 
 class RedisValidatorStorage(BaseRedisStorage):
     def __init__(self, config: Optional["Config"] = None):
         super().__init__(config)
+        self.validator_id = self.generate_user_id(config)
 
     def save_state(self, state: dict) -> None:
         """Save validator state to a single JSON file."""
         key = state.get("current_block")
-        self.save_data(key=key, data=state, prefix="state")
+        prefix = f"{self.validator_id}_state"
+        self.save_data(key=key, data=state, prefix=prefix)
 
     def get_state(self, block_number: int) -> dict:
         """Get validator state for specific block."""
-        return self.load_data(key=block_number, prefix="state")
+        prefix = f"{self.validator_id}_state"
+        return self.load_data(key=block_number, prefix=prefix)
 
     def load_latest_state(self) -> dict:
         """Load the latest saved validator state."""
-        return self.get_latest(prefix="state")
+        prefix = f"{self.validator_id}_state"
+        return self.get_latest(prefix=prefix)
 
 
 STORAGE_CLASSES = {"json": JsonValidatorStorage, "redis": RedisValidatorStorage}
 
 
 # Factory function to get storage
-def get_validator_storage(storage_type: str, config: "Config") -> Union["JsonValidatorStorage", "RedisValidatorStorage"]:
+def get_validator_storage(
+    storage_type: str, config: "Config"
+) -> Union["JsonValidatorStorage", "RedisValidatorStorage"]:
     """Get validator storage instance."""
     if storage_type not in STORAGE_CLASSES:
         raise ValueError(f"Unknown storage type: {storage_type}")

--- a/taohash/validator/storage.py
+++ b/taohash/validator/storage.py
@@ -11,21 +11,16 @@ class JsonValidatorStorage(BaseJsonStorage):
         super().__init__(config)
         self.validator_id = self.generate_user_id(config)
 
-    def save_state(self, block_number: int, state: dict) -> None:
+    def save_state(self, state: dict) -> None:
         """Save validator state to a single JSON file."""
         prefix = f"{self.validator_id}_state"
-        self.save_data(key=block_number, data=state, prefix=prefix)
+        self.save_data(key="current", data=state, prefix=prefix)
         logging.debug(f"Saved validator state at block {state['current_block']}")
-
-    def get_state(self, block_number: int) -> dict:
-        """Get validator state for specific block."""
-        prefix = f"{self.validator_id}_state"
-        return self.load_data(key=block_number, prefix=prefix)
 
     def load_latest_state(self) -> dict:
         """Load the latest saved validator state."""
         prefix = f"{self.validator_id}_state"
-        return self.get_latest(prefix=prefix)
+        return self.load_data(key="current", prefix=prefix)
 
 
 class RedisValidatorStorage(BaseRedisStorage):
@@ -35,19 +30,13 @@ class RedisValidatorStorage(BaseRedisStorage):
 
     def save_state(self, state: dict) -> None:
         """Save validator state to a single JSON file."""
-        key = state.get("current_block")
         prefix = f"{self.validator_id}_state"
-        self.save_data(key=key, data=state, prefix=prefix)
-
-    def get_state(self, block_number: int) -> dict:
-        """Get validator state for specific block."""
-        prefix = f"{self.validator_id}_state"
-        return self.load_data(key=block_number, prefix=prefix)
+        self.save_data(key="current", data=state, prefix=prefix)
 
     def load_latest_state(self) -> dict:
-        """Load the latest saved validator state."""
+        """Get validator state for specific block."""
         prefix = f"{self.validator_id}_state"
-        return self.get_latest(prefix=prefix)
+        return self.load_data(key="current", prefix=prefix)
 
 
 STORAGE_CLASSES = {"json": JsonValidatorStorage, "redis": RedisValidatorStorage}


### PR DESCRIPTION
- Don't create empty schedule when no pools
- Wait 10 minutes if no pools are found and query again
- Add user_ids in storage prefixes highlighting who the storage owner (wallet name, netuid, network etc)
- Adds args for storage choices in miner/vali
- Updates redis initialization 
- Updates vali storage to use only one file for persistence 
- Adds logging for slot when recovery done and same slot is valid. 