### PR TITLE
[feat] keeps old S1 config if it exists

### DIFF
--- a/taohash/miner/proxy/braiins_farm/controller.py
+++ b/taohash/miner/proxy/braiins_farm/controller.py
@@ -178,11 +178,11 @@ class BraiinsProxyManager(BaseProxyManager):
         try:
             if os.path.exists(self.config_path):
                 with open(self.config_path, "r") as f:
-                    config = toml.load(f)
+                    old_config = toml.load(f)
             else:
                 self._create_initial_config()
                 with open(self.config_path, "r") as f:
-                    config = toml.load(f)
+                    old_config = toml.load(f)
             
             # Initialize config structure
             config = {
@@ -196,6 +196,12 @@ class BraiinsProxyManager(BaseProxyManager):
                     "goal": []
                 }]
             }
+
+            # Copy over old server config, if it exists
+            if idx := next((i for i, s in enumerate(old_config["server"]) if s["name"] == "S1"), None):
+                for k, v in old_config["server"][idx].items():
+                    if k not in ["name", "port"]: # skip things added above
+                        config["server"][idx][k] = v
             
             # Add config for each target
             for target in slot_data.pool_targets:


### PR DESCRIPTION
This PR should keep fields in the proxy config, under the `server` section, if they already exist for `S1`, and are not overridden