### PR TITLE
Replace `subtensor.metagraph` with `subtensor.get_metagraph_info`

### DIFF
--- a/taohash/core/chain_data/pool_info.py
+++ b/taohash/core/chain_data/pool_info.py
@@ -2,12 +2,12 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-import netaddr
 import bt_decode
-
-from bittensor_wallet.bittensor_wallet import Wallet
+import netaddr
 from bittensor import logging
 from bittensor import subtensor as bt_subtensor
+from bittensor_wallet.bittensor_wallet import Wallet
+
 from taohash.core.utils import ip_to_int
 
 

--- a/taohash/core/pool/__init__.py
+++ b/taohash/core/pool/__init__.py
@@ -1,11 +1,10 @@
+import argparse
 from typing import Optional, Callable
 
-import argparse
-
-from taohash.core.pool.pool import PoolBase, PoolIndex
+from taohash.core.chain_data.pool_info import PoolInfo
 from taohash.core.pool.braiins import BraiinsPool
 from taohash.core.pool.config import PoolAPIConfig
-from taohash.core.chain_data.pool_info import PoolInfo
+from taohash.core.pool.pool import PoolBase, PoolIndex
 
 POOL_URLS_FMT: dict[PoolIndex, Callable[[PoolInfo], str]] = {
     PoolIndex.Braiins: lambda pool_info: f"stratum+tcp://{pool_info.domain}:{pool_info.port}",

--- a/taohash/core/pool/braiins/api.py
+++ b/taohash/core/pool/braiins/api.py
@@ -1,11 +1,10 @@
 from typing import Dict
 
-import requests
-from requests.exceptions import RequestException, JSONDecodeError
-from ratelimit import limits, RateLimitException
-from backoff import on_exception, expo
-
 import bittensor as bt
+import requests
+from backoff import on_exception, expo
+from ratelimit import limits, RateLimitException
+from requests.exceptions import RequestException, JSONDecodeError
 
 from taohash.core.pool.api import PoolAPI
 

--- a/taohash/core/pool/braiins/config.py
+++ b/taohash/core/pool/braiins/config.py
@@ -1,9 +1,9 @@
 import argparse
 import os
 
+from taohash.core.chain_data.pool_info import PoolInfo
 from taohash.core.pool.config import PoolAPIConfig
 from taohash.core.pool.pool import PoolIndex
-from taohash.core.chain_data.pool_info import PoolInfo
 
 
 class BraiinsPoolAPIConfig(PoolAPIConfig):

--- a/taohash/core/pool/braiins/pool.py
+++ b/taohash/core/pool/braiins/pool.py
@@ -1,9 +1,9 @@
 from typing import Dict
 
+from taohash.core.chain_data.pool_info import PoolInfo
 from taohash.core.pool.braiins.api import BraiinsPoolAPI
 from taohash.core.pool.braiins.config import BraiinsPoolAPIConfig
 from taohash.core.pool.pool import PoolBase, PoolIndex
-from taohash.core.chain_data.pool_info import PoolInfo
 
 
 class BraiinsPool(PoolBase):

--- a/taohash/core/pool/pool.py
+++ b/taohash/core/pool/pool.py
@@ -1,9 +1,9 @@
 import abc
 from enum import IntEnum
 
+from taohash.core.chain_data.pool_info import PoolInfo
 from taohash.core.pool.api import PoolAPI
 from taohash.core.pool.config import PoolAPIConfig
-from taohash.core.chain_data.pool_info import PoolInfo
 
 
 class PoolIndex(IntEnum):
@@ -63,7 +63,7 @@ class PoolBase(metaclass=abc.ABCMeta):
         Returns:
             Dictionary containing the miner's contribution metrics
         """
-        return
+        pass
 
     @abc.abstractmethod
     def get_all_miner_contributions(self, coin: str) -> dict[str, dict]:

--- a/taohash/core/pricing/__init__.py
+++ b/taohash/core/pricing/__init__.py
@@ -1,14 +1,14 @@
-from typing import Dict, Optional
 import argparse
+from typing import Dict, Optional
 
+from taohash.core.pricing.coingecko import CoinGeckoAPI
+from taohash.core.pricing.coinmarketcap import CoinMarketCapAPI
+from taohash.core.pricing.hash_price import BraiinsHashPriceAPI
 from taohash.core.pricing.price import (
     CoinPriceAPIBase,
     UnitCoinPriceAPI,
     HashPriceAPIBase,
 )
-from taohash.core.pricing.coingecko import CoinGeckoAPI
-from taohash.core.pricing.coinmarketcap import CoinMarketCapAPI
-from taohash.core.pricing.hash_price import BraiinsHashPriceAPI
 
 
 class CoinPriceAPI:

--- a/taohash/core/pricing/coingecko.py
+++ b/taohash/core/pricing/coingecko.py
@@ -1,5 +1,6 @@
-import requests
 from typing import Optional, Dict
+
+import requests
 
 from taohash.core.pricing.price import NetworkedCoinPriceAPI
 

--- a/taohash/core/pricing/coinmarketcap.py
+++ b/taohash/core/pricing/coinmarketcap.py
@@ -1,5 +1,6 @@
-import requests
 from typing import Dict
+
+import requests
 
 from taohash.core.pricing.price import NetworkedCoinPriceAPI
 

--- a/taohash/core/pricing/hash_price.py
+++ b/taohash/core/pricing/hash_price.py
@@ -1,7 +1,7 @@
+from typing import Dict, Optional
+
 import cachetools
 import requests
-
-from typing import Dict, Optional
 from backoff import expo, on_exception
 from cachetools import TTLCache
 from ratelimit import RateLimitException, limits

--- a/taohash/core/pricing/price.py
+++ b/taohash/core/pricing/price.py
@@ -1,6 +1,6 @@
+import abc
 from typing import Optional
 
-import abc
 import cachetools
 from cachetools import TTLCache
 

--- a/taohash/core/utils.py
+++ b/taohash/core/utils.py
@@ -1,7 +1,7 @@
 from typing import Optional, TypedDict
 
-import netaddr
 import bittensor
+import netaddr
 
 
 def ip_to_int(ip: str) -> int:

--- a/taohash/miner/allocation.py
+++ b/taohash/miner/allocation.py
@@ -135,7 +135,7 @@ class BaseAllocation(ABC):
         available_blocks_this_window: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.metagraph.Metagraph",
+        metagraph: "bt.Metagraph",
     ) -> list["MiningSlot"]:
         """
         Creates a mining schedule by distributing available blocks among validator pools.
@@ -163,7 +163,7 @@ class BaseAllocation(ABC):
         )
 
     def _filter_validators(
-        self, pool_info: dict[str, "PoolInfo"], metagraph: "bt.metagraph.Metagraph"
+        self, pool_info: dict[str, "PoolInfo"], metagraph: "bt.Metagraph"
     ) -> dict[str, "PoolInfo"]:
         """
         Filters and sorts validators based on multiple criteria.
@@ -234,7 +234,7 @@ class BaseAllocation(ABC):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.metagraph.Metagraph",
+        metagraph: "bt.Metagraph",
     ) -> list[MiningSlot]:
         """
         Abstract method that defines the core slot allocation logic for a specific strategy.
@@ -290,7 +290,7 @@ class StakeBased(BaseAllocation):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.metagraph.Metagraph",
+        metagraph: "bt.Metagraph",
     ) -> list[MiningSlot]:
         filtered = self._filter_validators(pool_info, metagraph)
         if not filtered:
@@ -387,7 +387,7 @@ class MultiPoolStakeAllocation(BaseAllocation):
         self,
         window: int,
         validator_list: list[str],
-        metagraph: "bt.metagraph.Metagraph",
+        metagraph: "bt.Metagraph",
     ) -> dict[str, int]:
         # Allocate min blocks to each validator
         quotas = {hk: self.min_blocks_per_validator for hk in validator_list}
@@ -415,7 +415,7 @@ class MultiPoolStakeAllocation(BaseAllocation):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.metagraph.Metagraph",
+        metagraph: "bt.Metagraph",
     ) -> list[MiningSlot]:
         validators = self._filter_validators(pool_info, metagraph)
         if not validators:
@@ -499,7 +499,6 @@ class MultiPoolStakeAllocation(BaseAllocation):
 # TODO: EMA Stake Based
 class EMAStakeBased(BaseAllocation):
     """Allocates blocks proportionally based on EMA of stake"""
-
     pass
 
 
@@ -525,7 +524,7 @@ class EqualDistribution(BaseAllocation):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.metagraph.Metagraph",
+        metagraph: "bt.Metagraph",
     ) -> list[MiningSlot]:
         filtered = self._filter_validators(pool_info, metagraph)
         if not filtered:

--- a/taohash/miner/allocation.py
+++ b/taohash/miner/allocation.py
@@ -135,7 +135,7 @@ class BaseAllocation(ABC):
         available_blocks_this_window: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
     ) -> list["MiningSlot"]:
         """
         Creates a mining schedule by distributing available blocks among validator pools.
@@ -163,7 +163,7 @@ class BaseAllocation(ABC):
         )
 
     def _filter_validators(
-        self, pool_info: dict[str, "PoolInfo"], metagraph: "bt.Metagraph"
+        self, pool_info: dict[str, "PoolInfo"], metagraph: "bt.MetagraphInfo"
     ) -> dict[str, "PoolInfo"]:
         """
         Filters and sorts validators based on multiple criteria.
@@ -234,7 +234,7 @@ class BaseAllocation(ABC):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
     ) -> list[MiningSlot]:
         """
         Abstract method that defines the core slot allocation logic for a specific strategy.
@@ -290,7 +290,7 @@ class StakeBased(BaseAllocation):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
     ) -> list[MiningSlot]:
         filtered = self._filter_validators(pool_info, metagraph)
         if not filtered:
@@ -313,7 +313,8 @@ class StakeBased(BaseAllocation):
             stake = metagraph.total_stake[metagraph.hotkeys.index(hotkey)]
             fair_share = int((stake / total_stake) * available_blocks)
             bt.logging.info(
-                f"\nHotkey: {hotkey} - Stake_weight: {(stake / total_stake)} ({stake:.2f} / {total_stake:.2f}). Allocated: {fair_share} / {available_blocks}"
+                f"\nHotkey: {hotkey} - Stake_weight: {(stake / total_stake)} ({stake:.2f} / {total_stake:.2f}). "
+                f"Allocated: {fair_share} / {available_blocks}"
             )
 
             blocks_allocated = max(
@@ -387,7 +388,7 @@ class MultiPoolStakeAllocation(BaseAllocation):
         self,
         window: int,
         validator_list: list[str],
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
     ) -> dict[str, int]:
         # Allocate min blocks to each validator
         quotas = {hk: self.min_blocks_per_validator for hk in validator_list}
@@ -415,7 +416,7 @@ class MultiPoolStakeAllocation(BaseAllocation):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
     ) -> list[MiningSlot]:
         validators = self._filter_validators(pool_info, metagraph)
         if not validators:
@@ -524,7 +525,7 @@ class EqualDistribution(BaseAllocation):
         available_blocks: int,
         next_window_block: int,
         pool_info: dict[str, "PoolInfo"],
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
     ) -> list[MiningSlot]:
         filtered = self._filter_validators(pool_info, metagraph)
         if not filtered:

--- a/taohash/miner/braiins.py
+++ b/taohash/miner/braiins.py
@@ -146,8 +146,8 @@ class BraiinsMiner(BaseMiner):
             4. Handle first sync and schedule recovery
             5. Update mining schedule based on current network state
         """
-        self.metagraph.sync()
-        self.current_block = self.metagraph.block.item()
+        self.metagraph = self.subtensor.get_metagraph_info(netuid=self.config.netuid)
+        self.current_block = self.metagraph.block
         logging.info(f"Syncing at block {self.current_block}")
 
         target_pools = self.get_target_pools()
@@ -250,7 +250,7 @@ class BraiinsMiner(BaseMiner):
                         f"Block: {self.current_block} | "
                         f"Next sync: {next_sync_block} | "
                         f"Reason: {sync_reason} | "
-                        f"Incentive: {self.metagraph.I[self.uid]} | "
+                        f"Incentive: {self.metagraph.incentives[self.uid]} | "
                         f"Blocks since epoch: {self.metagraph.blocks_since_last_step}"
                     )
                 else:

--- a/taohash/miner/braiins.py
+++ b/taohash/miner/braiins.py
@@ -1,16 +1,16 @@
 import argparse
 import traceback
 
-from dotenv import load_dotenv
 from bittensor import logging
+from dotenv import load_dotenv
 
 from taohash.core.chain_data.pool_info import get_all_pool_info, PoolInfo
-from taohash.miner.scheduler import MiningScheduler
-from taohash.miner.proxy.braiins_farm.controller import BraiinsProxyManager
-from taohash.miner.allocation import get_allocation
 from taohash.core.constants import BLOCK_TIME
 from taohash.core.pool import PoolIndex
 from taohash.miner import BaseMiner
+from taohash.miner.allocation import get_allocation
+from taohash.miner.proxy.braiins_farm.controller import BraiinsProxyManager
+from taohash.miner.scheduler import MiningScheduler
 
 DEFAULT_SYNC_FREQUENCY = 6
 
@@ -209,7 +209,7 @@ class BraiinsMiner(BaseMiner):
             # If we have a mining slot, check when it ends
             current_schedule = self.mining_scheduler.current_schedule
             slot_end = current_schedule.current_slot.end_block + 1
-            if slot_end >= self.current_block and slot_end < next_sync:
+            if self.current_block <= slot_end < next_sync:
                 next_sync = slot_end
                 if slot_end == current_schedule.end_block + 1:
                     sync_reason = "New window"
@@ -260,7 +260,7 @@ class BraiinsMiner(BaseMiner):
             except KeyboardInterrupt:
                 logging.success("Miner killed by keyboard interrupt.")
                 break
-            except Exception as e:
+            except Exception:
                 logging.error(traceback.format_exc())
                 continue
 

--- a/taohash/miner/proxy/base.py
+++ b/taohash/miner/proxy/base.py
@@ -1,8 +1,9 @@
+import argparse
+import os
 from abc import ABC, abstractmethod
 from typing import Optional, Tuple, Any
-import argparse
+
 import bittensor as bt
-import os
 
 
 class BaseProxyManager(ABC):
@@ -63,4 +64,4 @@ class BaseProxyManager(ABC):
         Returns:
             bool: True if update was successful
         """
-        pass 
+        pass

--- a/taohash/miner/proxy/braiins_farm/controller.py
+++ b/taohash/miner/proxy/braiins_farm/controller.py
@@ -10,6 +10,7 @@ from taohash.miner.proxy.base import BaseProxyManager
 
 DEFAULT_PROXY_BASE_PATH = os.path.abspath(os.path.dirname(__file__))
 
+
 class BraiinsProxyManager(BaseProxyManager):
     """
     Manager for Braiins Farm Proxy configuration.
@@ -119,7 +120,8 @@ class BraiinsProxyManager(BaseProxyManager):
                 capture_output=True,
                 text=True
             )
-            
+
+            bt.logging.debug(f"Docker compose up result: {result.stdout}")
             bt.logging.success("Successfully refreshed proxy configuration")
             return True
                 
@@ -200,7 +202,7 @@ class BraiinsProxyManager(BaseProxyManager):
             # Copy over old server config, if it exists
             if idx := next((i for i, s in enumerate(old_config["server"]) if s["name"] == "S1"), None):
                 for k, v in old_config["server"][idx].items():
-                    if k not in ["name", "port"]: # skip things added above
+                    if k not in ["name", "port"]:  # skip things added above
                         config["server"][idx][k] = v
             
             # Add config for each target

--- a/taohash/miner/scheduler.py
+++ b/taohash/miner/scheduler.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Union, TYPE_CHECKING
 
 import bittensor as bt
 from tabulate import tabulate
@@ -6,7 +6,7 @@ from tabulate import tabulate
 from taohash.miner.models import MiningSlot, MiningSchedule
 
 if TYPE_CHECKING:
-    from taohash.miner.storage import BaseStorage
+    from taohash.miner.storage import JsonStorage, RedisStorage
     from taohash.miner.allocation import BaseAllocation
 
 
@@ -30,8 +30,8 @@ class MiningScheduler:
     def __init__(
         self,
         config: "bt.Config",
-        metagraph: "bt.metagraph.Metagraph",
-        storage: "BaseStorage",
+        metagraph: "bt.Metagraph",
+        storage: Union["JsonStorage", "RedisStorage"],
         allocation: "BaseAllocation",
         window_size: int,
         proxy_manager=None,
@@ -93,7 +93,7 @@ class MiningScheduler:
         return schedule
 
     def update_mining_schedule(
-        self, current_block: int, metagraph: "bt.metagraph.Metagraph" = None
+        self, current_block: int, metagraph: "bt.Metagraph" = None
     ) -> Optional["MiningSlot"]:
         """
         Update the mining schedule and current slot based on the current block.

--- a/taohash/miner/scheduler.py
+++ b/taohash/miner/scheduler.py
@@ -30,7 +30,7 @@ class MiningScheduler:
     def __init__(
         self,
         config: "bt.Config",
-        metagraph: "bt.Metagraph",
+        metagraph: "bt.MetagraphInfo",
         storage: Union["JsonStorage", "RedisStorage"],
         allocation: "BaseAllocation",
         window_size: int,
@@ -93,7 +93,7 @@ class MiningScheduler:
         return schedule
 
     def update_mining_schedule(
-        self, current_block: int, metagraph: "bt.Metagraph" = None
+        self, current_block: int, metagraph: "bt.MetagraphInfo" = None
     ) -> Optional["MiningSlot"]:
         """
         Update the mining schedule and current slot based on the current block.

--- a/taohash/validator/__init__.py
+++ b/taohash/validator/__init__.py
@@ -31,6 +31,7 @@ class BaseValidator:
         self.subtensor = None
         self.wallet = None
         self.metagraph = None
+        self.tempo = None
         self.uid = None
         self.weights_interval = None
 
@@ -294,7 +295,7 @@ class BaseValidator:
 
         # Sort by weight (highest first)
         sorted_indices = sorted(
-            range(len(weights)), key=lambda i: weights[i], reverse=True
+            range(len(weights)), key=lambda w: weights[w], reverse=True
         )
 
         for i in sorted_indices:
@@ -327,7 +328,7 @@ class BaseValidator:
 
         # Sort by score (highest first)
         sorted_indices = sorted(
-            range(len(self.scores)), key=lambda i: self.scores[i], reverse=True
+            range(len(self.scores)), key=lambda s: self.scores[s], reverse=True
         )
 
         for i in sorted_indices:

--- a/taohash/validator/braiins.py
+++ b/taohash/validator/braiins.py
@@ -15,11 +15,11 @@ from taohash.core.chain_data.pool_info import (
     get_pool_info,
     encode_pool_info,
 )
+from taohash.core.constants import VERSION_KEY
 from taohash.core.pool import Pool, PoolBase
 from taohash.core.pool.braiins.config import BraiinsPoolAPIConfig, BraiinsPoolConfig
 from taohash.core.pool.metrics import get_metrics_for_miners, MiningMetrics
 from taohash.core.pricing import BraiinsHashPriceAPI, HashPriceAPIBase
-from taohash.core.constants import VERSION_KEY
 from taohash.validator import BaseValidator
 
 COIN = "bitcoin"

--- a/taohash/validator/braiins.py
+++ b/taohash/validator/braiins.py
@@ -121,9 +121,9 @@ class BraiinsValidator(BaseValidator):
             for metric in miner_metrics:
                 uid = hotkey_to_uid[metric.hotkey]
                 if timeframe == "5m":
-                    mining_value: float = metric.get_value_last_5m(hash_price)
+                    mining_value = metric.get_value_last_5m(hash_price)
                 else:  # "60m"
-                    mining_value: float = metric.get_value_past_hour(hash_price)
+                    mining_value = metric.get_value_past_hour(hash_price)
 
                 if mining_value > 0:
                     logging.info(


### PR DESCRIPTION
This PR addresses performance concerns related to the `subtensor.metagraph()` property, which internally takes approximately 3x longer to execute compared to a direct call to `subtensor.get_metagraph_info()`.

I compared 100 calls to subnets in the Finney network in my location:
- 100 `subtensor.metagraph` calls take `46.80` seconds
- 100 `subtensor.get_metagraph_info` calls take `16.09` seconds
The second one is `2.91` times faster than the first one