### PR TITLE
fix: skip mining.set_version_mask notification during subscribe hands…

### DIFF
--- a/taohash/miner/proxy/taohash_proxy/src/pool_session.py
+++ b/taohash/miner/proxy/taohash_proxy/src/pool_session.py
@@ -136,13 +136,18 @@ class PoolSession:
                 f"Sent subscription request with id {subscription_id}",
             )
 
-            subscription_response_raw = await pool_reader.readline()
-            subscription_response = json.loads(subscription_response_raw.decode())
-            log_stratum_message(
-                logger,
-                subscription_response,
-                f"Received subscription response: {subscription_response}",
-            )
+            # GSW Edited this as it was broken
+            subscription_response = None
+            while subscription_response is None:
+                subscription_response_raw = await pool_reader.readline()
+                msg = json.loads(subscription_response_raw.decode())
+                log_stratum_message(logger, msg, f"Received message during subscribe: {msg}")
+                if msg.get('id') == subscription_id:
+                    subscription_response = msg
+                else:
+                    logger.info(f"Skipping notification during subscribe: {msg.get('method')}")
+            # end edit
+
 
             # Parse and store subscription_ids, extranonce1, extranonce2_size
             subscription_result = subscription_response.get("result", [])


### PR DESCRIPTION
fix: skip mining.set_version_mask notification during subscribe handshake

When ASIC miners send mining.configure for version-rolling/ASICBoost, the TAOHash pool responds with a mining.set_version_mask notification before the subscribe response. The proxy was reading this notification as the subscribe response and crashing with 'list index out of range'.

Fix loops until a message matching the subscription_id is received, skipping any intermediate notifications.

Tested with Bitaxe running AxeOS connecting to btc.taohash.com:3331