### PR TITLE
docs: fix registration links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ See: [TAOHash miner guide](/docs/running_miner.md)
 **Related Bittensor Documentation**:
 
 - [Wallets, Coldkeys and Hotkeys in Bittensor](https://docs.learnbittensor.org/getting-started/wallets)
-- [Miner registration](./miners/index.md#miner-registration)
+- [Miner registration](https://docs.learnbittensor.org/miners#miner-registration)
 
 ## Validator Requirements
 
@@ -108,7 +108,7 @@ See: [TAOHash validator guide](/docs/running_validator.md)
 
 **Related Bittensor Documentation**:
 - [Wallets, Coldkeys and Hotkeys in Bittensor](https://docs.learnbittensor.org/getting-started/wallets)
-- [Validator registration](./validators/index.md#validator-registration)
+- [Validator registration](https://docs.learnbittensor.org/validators#validator-registration)
 
 # Installation
 

--- a/docs/running_miner.md
+++ b/docs/running_miner.md
@@ -66,7 +66,7 @@ To run a TaoHash miner, you will need:
 Bittensor Docs:
 
 - [Wallets, Coldkeys and Hotkeys in Bittensor](https://docs.learnbittensor.org/getting-started/wallets)
-- [Miner registration](./miners/index.md#miner-registration)
+- [Miner registration](https://docs.learnbittensor.org/miners#miner-registration)
 
 ## Quick Start
 

--- a/docs/running_validator.md
+++ b/docs/running_validator.md
@@ -26,7 +26,7 @@ See also:
 Bittensor Docs:
 
 - [Requirements for Validation](https://docs.learnbittensor.org/validators/#requirements-for-validation)
-- [Validator registration](./validators/index.md#validator-registration)
+- [Validator registration](https://docs.learnbittensor.org/validators#validator-registration)
 - [Wallets, Coldkeys and Hotkeys in Bittensor](https://docs.learnbittensor.org/getting-started/wallets)
 
 ## Setup Steps


### PR DESCRIPTION
## Summary

- replace broken relative miner/validator registration links with the public Learn Bittensor docs

## Why

The current links point to `./miners/index.md` and `./validators/index.md`, but those paths do not exist in this repository. The updated links send readers to the official miner and validator docs.

## Test

Docs-only change. Verified with:

```bash
git diff --check
```
