### PR TITLE
fix(deps): resolve scalecodec/cyscale namespace conflict and pin asyn…fix(deps): resolve scalecodec/cyscale namespace conflict and pin async-substrate-interface<2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ authors = [
 ]
 dependencies = [
     "bittensor>=9.9.0,<10.0.0",
+    "async-substrate-interface>=1.5.6,<2.0.0",
+    "cyscale>=0.4.0",
     "ratelimit==2.2.1",
     "cachetools==5.3.1",
     "tabulate~=0.9.0",


### PR DESCRIPTION
…c-substrate-interface<2.0.0## Summary
Fixes a critical namespace collision that prevents `python -m taohash.miner.miner` from starting on a clean install.

## Problem
`bittensor>=9.9.0` pulls in `async-substrate-interface 2.x` which is a breaking major version — bittensor 9.x expects `1.x`, causing an `ImportError: cannot import name 'ScaleObj'` on startup.

Additionally, `async-substrate-interface` raises a `RuntimeError` if both `scalecodec` (py-scale-codec) and `cyscale` are simultaneously present, since both occupy the same `scalecodec` Python namespace.

## Fix
- Pinned `async-substrate-interface>=1.5.6,<2.0.0` to stay on the compatible 1.x range
- Added `cyscale>=0.4.0` as a drop-in replacement for `py-scale-codec`

## Testing

```bash
python3.12 -m venv .venv && source .venv/bin/activate
pip install -e .
pip uninstall scalecodec -y && pip install cyscale --force-reinstall
python -m taohash.miner.miner --help  # starts cleanly
```